### PR TITLE
Minor email list speedup

### DIFF
--- a/src/src/AvatarService.js
+++ b/src/src/AvatarService.js
@@ -53,8 +53,8 @@ export default class AvatarService {
         console.warn("Too many requests in progress, skipping avatar fetch for " + author);
         return null;
       }
-      const mailObject = await Mail.fromAuthor(author);
       this.sessionCacheAvatarUrls[author] = Status.WAITING;
+      const mailObject = await Mail.fromAuthor(author);
       const profilePictureFetcher = new ProfilePictureFetcher(window, mailObject);
       this.sessionCacheAvatarUrls[author] = await profilePictureFetcher.getAvatar();
     }

--- a/src/src/AvatarService.js
+++ b/src/src/AvatarService.js
@@ -48,19 +48,20 @@ export default class AvatarService {
    * @returns {Promise<string|null>} - The avatar URL or null if request limit exceeded or not found.
    */
   async getAvatar(author) {
-    if (!this.sessionCacheAvatarUrls[author]) {
+    let lcAuthor = author.toLowerCase();
+    if (!this.sessionCacheAvatarUrls[lcAuthor]) {
       if (this.countWaitingAvatars() > defaultSettings.MAX_REQUEST_SIZE) {
         console.warn("Too many requests in progress, skipping avatar fetch for " + author);
         return null;
       }
-      this.sessionCacheAvatarUrls[author] = Status.WAITING;
+      this.sessionCacheAvatarUrls[lcAuthor] = Status.WAITING;
       const mailObject = await Mail.fromAuthor(author);
       const profilePictureFetcher = new ProfilePictureFetcher(window, mailObject);
-      this.sessionCacheAvatarUrls[author] = await profilePictureFetcher.getAvatar();
+      this.sessionCacheAvatarUrls[lcAuthor] = await profilePictureFetcher.getAvatar();
     }
-    while (this.sessionCacheAvatarUrls[author] === Status.WAITING) {
+    while (this.sessionCacheAvatarUrls[lcAuthor] === Status.WAITING) {
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
-    return this.sessionCacheAvatarUrls[author];
+    return this.sessionCacheAvatarUrls[lcAuthor];
   }
 }


### PR DESCRIPTION
The cached avatars are marked as waiting after the first await call so they are not marked fast enough.
Additionally, the cache should be based on a lowercase key to avoid some duplication.