### PR TITLE
chore: bump max TB version to 141

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -42,7 +42,7 @@
     "gecko": {
       "id": "autoprofilepicture@astucesweb.fr",
       "strict_min_version": "112.0",
-      "strict_max_version": "140.*"
+      "strict_max_version": "141.*"
     }
   }
 }


### PR DESCRIPTION
I tested with Thunderbird beta 141.0b3 (flatpak), works without any issues so I bumped the supported max version to reflect that.

<img width="1032" height="611" alt="image" src="https://github.com/user-attachments/assets/b11fa0d1-7704-4f1c-af93-9d031b6e40d8" />

Merci pour l'extension, this is the only thing I needed to finally ditch Outlook and daily drive Thunderbird :)